### PR TITLE
Fix cancel button text

### DIFF
--- a/src/_root/pages/GroupDetails.tsx
+++ b/src/_root/pages/GroupDetails.tsx
@@ -282,7 +282,7 @@ const GroupDetails = () => {
               If deleted, the Group expense will be permanently removed.
             </p>
             <Button className="btn bg-red hover:bg-red" onClick={toggleModal2}>
-              Cancle
+              Cancel
             </Button>
             <Button className="btn m-2 bg-green-400" onClick={handleDelete}>
               Confirm

--- a/src/components/shared/GroupActivity.tsx
+++ b/src/components/shared/GroupActivity.tsx
@@ -142,7 +142,7 @@ const GroupActivity = ({ activity }: UserCardProps) => {
               If deleted, the expense will be permanently removed.
             </p>
             <Button className="btn bg-red hover:bg-red" onClick={toggleModal}>
-              Cancle
+              Cancel
             </Button>
             <Button className="btn m-2 bg-green-600" onClick={handleDelete}>
               Confirm

--- a/src/components/shared/UserCard.tsx
+++ b/src/components/shared/UserCard.tsx
@@ -182,7 +182,7 @@ const UserCard: React.FC<UserCardProps> = ({
               repayment between two user
             </p>
             <Button className="btn bg-red hover:bg-red" onClick={toggleModal}>
-              Cancle
+              Cancel
             </Button>
             <Button className="btn m-2 bg-green-400" onClick={toggleModal}>
               Confirm


### PR DESCRIPTION
## Summary
- fix spelling of Cancel button in Group details modal
- correct cancel button in activity modal and user card

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684e58247b0c832f9db156dbc71594c6