### PR TITLE
Add theme switcher

### DIFF
--- a/src/components/shared/ThemeToggle.tsx
+++ b/src/components/shared/ThemeToggle.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+const ThemeToggle = () => {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem("theme");
+    if (storedTheme === "dark") {
+      document.documentElement.classList.add("dark");
+      setIsDark(true);
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    if (isDark) {
+      document.documentElement.classList.remove("dark");
+      localStorage.setItem("theme", "light");
+    } else {
+      document.documentElement.classList.add("dark");
+      localStorage.setItem("theme", "dark");
+    }
+    setIsDark(!isDark);
+  };
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className="p-2 rounded transition-colors hover:bg-gray-700 focus:outline-none"
+    >
+      {isDark ? <Sun className="w-5 h-5 text-yellow-300" /> : <Moon className="w-5 h-5 text-gray-900" />}
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/shared/Topbar.tsx
+++ b/src/components/shared/Topbar.tsx
@@ -1,10 +1,11 @@
 import { Link } from "react-router-dom";
+import { ThemeToggle } from "@/components/shared";
 
 const Topbar = () => {
   return (
     <section className="topbar">
       <nav className="bg-gray-800 p-4">
-        <div className="container font-sans mx-auto flex justify-evenly items-center pe-8">
+        <div className="container font-sans mx-auto flex justify-between items-center pe-8">
           <Link
             to="/"
             className="text-white font-bold text-lg flex items-center">
@@ -18,6 +19,7 @@ const Topbar = () => {
             </span>
             TripLedger
           </Link>
+          <ThemeToggle />
         </div>
       </nav>
     </section>

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -4,3 +4,4 @@ export { default as Loader } from "./Loader";
 export { default as PostCard } from "./PostCard";
 export { default as Topbar } from "./Topbar";
 export { default as UserCard } from "./UserCard";
+export { default as ThemeToggle } from "./ThemeToggle";

--- a/src/globals.css
+++ b/src/globals.css
@@ -11,15 +11,14 @@
   }
 
   body {
+    @apply bg-white text-black transition-colors duration-300 min-h-screen font-["Inter",_sans-serif];
+  }
+
+  .dark body {
     background: #485563;
-    /* fallback for old browsers */
     background: -webkit-linear-gradient(to top, #29323c, #485563);
-    /* Chrome 10-25, Safari 5.1-6 */
     background: linear-gradient(to top, #29323c, #485563);
-    /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
-    color: white;
-    min-height: 80vh;
-    font-family: 'Inter', sans-serif;
+    @apply text-white;
   }
 }
 


### PR DESCRIPTION
## Summary
- add ThemeToggle component to switch between light and dark mode
- show ThemeToggle in the Topbar
- support light and dark backgrounds in `globals.css`

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684e5a830570832f8cf265f353486e9e