### PR TITLE
Improve SEO and add dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-confirm-alert": "^3.0.6",
         "react-dom": "^18.2.0",
         "react-dropzone": "^14.2.3",
+        "react-helmet-async": "^2.0.5",
         "react-hook-form": "^7.47.0",
         "react-intersection-observer": "^9.5.3",
         "react-modal": "^3.16.1",
@@ -3725,6 +3726,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -4851,6 +4861,26 @@
         "react": ">= 16.8 || 18.0.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-hook-form": {
       "version": "7.49.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.2.tgz",
@@ -5202,6 +5232,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-confirm-alert": "^3.0.6",
     "react-dom": "^18.2.0",
     "react-dropzone": "^14.2.3",
+    "react-helmet-async": "^2.0.5",
     "react-hook-form": "^7.47.0",
     "react-intersection-observer": "^9.5.3",
     "react-modal": "^3.16.1",

--- a/src/_root/RootLayout.tsx
+++ b/src/_root/RootLayout.tsx
@@ -7,9 +7,10 @@ import LeftSidebar from "@/components/shared/LeftSidebar";
 const RootLayout = () => {
   return (
     <div className="w-full md:flex">
+      <a href="#main" className="sr-only focus:not-sr-only">Skip to main content</a>
       <Topbar />
       <LeftSidebar />
-      <section className="flex flex-1 h-full">
+      <section id="main" className="flex flex-1 h-full">
         <Outlet />
       </section>
       <Bottombar />

--- a/src/_root/pages/Home.tsx
+++ b/src/_root/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { Models } from "appwrite";
 import { Loader, PostCard } from "@/components/shared";
+import PageHead from "@/components/shared/PageHead";
 import { useNavigate } from "react-router-dom";
 import { useGetCurrentUser } from "@/lib/react-query/queries";
 
@@ -28,8 +29,10 @@ const Home = () => {
     );
   }
   return (
-    <div className="common-container">
-      <div className="user-container">
+    <>
+      <PageHead title="Home" description="Manage your trip groups" />
+      <div className="common-container">
+        <div className="user-container">
         <div className="container p-5 flex flex-col">
           <h2 className="text-white text-2xl font-bold mb-6">
             Groups
@@ -65,6 +68,7 @@ const Home = () => {
         </div>
       </div>
     </div>
+    </>
   );
 };
 

--- a/src/components/shared/PageHead.tsx
+++ b/src/components/shared/PageHead.tsx
@@ -1,0 +1,25 @@
+import { Helmet } from 'react-helmet-async';
+
+interface PageHeadProps {
+  title: string;
+  description?: string;
+  image?: string;
+}
+
+export default function PageHead({ title, description, image }: PageHeadProps) {
+  const metaDescription = description ?? 'Track group expenses with TripLedger.';
+  const metaImage = image ?? '/assets/images/split-logo.png';
+  return (
+    <Helmet>
+      <title>{title} | TripLedger</title>
+      <meta name="description" content={metaDescription} />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={metaDescription} />
+      <meta property="og:image" content={metaImage} />
+      <meta property="og:type" content="website" />
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:image" content={metaImage} />
+      <link rel="canonical" href="https://tripledger.example.com" />
+    </Helmet>
+  );
+}

--- a/src/components/shared/ThemeToggle.tsx
+++ b/src/components/shared/ThemeToggle.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('theme') as 'light' | 'dark') || 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return (
+    <button
+      aria-label="Toggle dark mode"
+      className="p-2 rounded focus:outline-none"
+      onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+    >
+      {theme === 'light' ? '🌙' : '☀️'}
+    </button>
+  );
+}

--- a/src/components/shared/Topbar.tsx
+++ b/src/components/shared/Topbar.tsx
@@ -1,10 +1,11 @@
 import { Link } from "react-router-dom";
+import ThemeToggle from "./ThemeToggle";
 
 const Topbar = () => {
   return (
     <section className="topbar">
       <nav className="bg-gray-800 p-4">
-        <div className="container font-sans mx-auto flex justify-evenly items-center pe-8">
+        <div className="container font-sans mx-auto flex justify-between items-center pe-8">
           <Link
             to="/"
             className="text-white font-bold text-lg flex items-center">
@@ -18,6 +19,7 @@ const Topbar = () => {
             </span>
             TripLedger
           </Link>
+          <ThemeToggle />
         </div>
       </nav>
     </section>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
 
 import { AuthProvider } from "@/context/AuthContext";
 import { QueryProvider } from "@/lib/react-query/QueryProvider";
@@ -10,13 +11,15 @@ import { Toaster } from "./components/ui/toaster";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <QueryProvider>
-        <AuthProvider>
-          <App />
-          <Toaster />
-        </AuthProvider>
-      </QueryProvider>
-    </BrowserRouter>
+    <HelmetProvider>
+      <BrowserRouter>
+        <QueryProvider>
+          <AuthProvider>
+            <App />
+            <Toaster />
+          </AuthProvider>
+        </QueryProvider>
+      </BrowserRouter>
+    </HelmetProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add react-helmet-async for page metadata
- create PageHead component for SEO tags
- implement skip to content and dark mode toggle

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688636017970832fa2b86fb3772bc1eb